### PR TITLE
Fix: No block production when no peer is set

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "peers": [],
+  "peers": [{"ip":"127.0.0.1","port":4096}],
   "secrets": [
     "flame bottom dragon rely endorse garage supply urge turtle team demand put",
     "thrive veteran child enforce puzzle buzz valley crew genuine basket start top",


### PR DESCRIPTION
Dear @liangpeili

with this pull request the __asch-dapp-helloworld__ dapp will produce blocks when running on ASCH 1.4

All the best
a1300